### PR TITLE
Fixup some schema expectations

### DIFF
--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -178,10 +178,11 @@ def cert(name,
     else:
         comment = 'Certificate {0} obtained'.format(name)
 
-    ret = __salt__['file.check_perms'](_cert_file(name, 'privkey'),
-                                       {'comment': comment, 'not_after': expires(name)},
-                                       owner, group, mode,
-                                       follow_symlinks=True)
+    ret = {'comment': comment, 'not_after': expires(name), 'changes': {}, 'result': True}
+    ret, perms = __salt__['file.check_perms'](_cert_file(name, 'privkey'),
+                                              ret,
+                                              owner, group, mode,
+                                              follow_symlinks=True)
 
     return ret
 


### PR DESCRIPTION
The `acme.cert` state makes some assumptions about the return of `acme.cert` executor.